### PR TITLE
add support for multiple named mirrors in same location

### DIFF
--- a/MMM-AlexaControl.js
+++ b/MMM-AlexaControl.js
@@ -25,7 +25,7 @@ Module.register("MMM-AlexaControl",{
         shutdown: false,    //  shutdown your pi
         pm2ProcessName: "mm",  //  name of your pm2 process
         monitorToggle: true,   //  sitch your monitor on and off
-        vcgencmd: true      //  command you use for monitor toggle
+        vcgencmd: 'vcgencmd'      //  command you use for monitor toggle
     },
 
     getTranslations: function(){            // add more translations
@@ -39,7 +39,7 @@ Module.register("MMM-AlexaControl",{
         Log.log('Starting module: ' + this.name);
 
         // send all translations to node_helper
-        this.sendSocketNotification('TRANSLATIONS', {"monitor": this.translate("MONITOR"), "shutdown": this.translate("SHUTDOWN"), "reboot": this.translate("REBOOT"), "page": this.translate("PAGE"), "refresh": this.translate("REFRESH"), "restart": this.translate("RESTART"), "stop": this.translate("STOP")});
+        this.sendSocketNotification('TRANSLATIONS', {"monitor": this.translate("MONITOR"), "shutdown": this.translate("SHUTDOWN"), "reboot": this.translate("REBOOT"), "page": this.translate("PAGE"), "refresh": this.translate("REFRESH"), "restart": this.translate("RESTART"), "stop": this.translate("STOP"), "deviceName":this.translate(this.config.deviceName)});
         this.sendSocketNotification('SET_DEVICE', this.config);  // send the config to node_helper
     },
 
@@ -64,8 +64,13 @@ Module.register("MMM-AlexaControl",{
             if(payload === "refresh"){
                 window.location.reload(true);
             }
-        }if(notification === "CUSTOM"){
+        } 
+        if(notification === "CUSTOM"){
             this.sendNotification(payload[0], payload[1]);  //  send any notification to any module
+        }
+        if(notification =='MONITOR_ACTION'){
+            Log.log('RECEIVE monitor NOTIFICATION='+payload)
+            this.sendNotification(notification,payload)
         }
     }
  });

--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ The following properties can be configured:
 | `height`          | Here you can change the image height. <br> **Default Value:** `265` ***Note:*** The unit is px.
 | `wight`           | Here you can change the image width. <br> **Default Value:** `265` ***Note:*** The unit is px.
 | `pm2ProcessName`  | If you want to restart your Mirror with PM2 change here your PM2 processname. [Here](https://github.com/MichMich/MagicMirror/wiki/Auto-Starting-MagicMirror) you can configure PM2 for your Mirror. <br> **Default value:** `mm`
-| `vcgencmd`        | This option chose the command to toggle your monitor on and off. I found two commands. Test them before in the terminal. <br> **Default value:** `true` <br> **Possible values:**<br> `true` = `vcgencmd display_power 0` and `vcgencmd display_power 1` <br>`false` = `tvservice --off` and `tvservice --preferred`
-| `startPort`       | First Port for the devices. The port identify the device. So delete old devices in the Alexa App to prevent issues. Normaly you don't have to change it. <br> **Default value:** `11000`
+| `vcgencmd`        | This option chose the command to toggle your monitor on and off. I found two commands. Test them before in the terminal. <br> **Default value:** `vcgencmd` <br> **Possible values:**<br> `vcgencmd` = `vcgencmd display_power 0` and `vcgencmd display_power 1` <br>`tvservice` = `tvservice --off` and `tvservice --preferred` <br> `hide` = use module hiding on devices that do not supporot either of the other two chocies
+| `startPort`       | First Port for the devices. The port identify the device. So delete old devices in the Alexa App to prevent issues. Normaly you don't have to change it. <br> **Default value:** `11000`|
+| `deviceName` | this option allows you to provide a name for this MM installation, useful if u have more than one Mirror installation. the alexa device names will include this name <br> **Default value:** not used
 
 ### Control devices
 These are configured devices you can use. If you want to change their name you must edit the translation file inside `/translations/en.json`. You can also add languages.
@@ -110,7 +111,7 @@ notifications: [
 ]
 ````
 ***Note:*** `NOTIFICATION ON` and `NOTIFICATION OFF` stay for the different notifications you can send when you turn on or off the device. The same thing applies to `PAYLOAD ON` and `PAYLOAD OFF`. <br> <br>
-These are the configuration options for a notification device: <br> ***Note:*** They are all necessary. 
+These are the configuration options for a notification device: <br> ***Note:*** They are all necessary.
 
 | Option            | Description
 | ----------------- | -----------


### PR DESCRIPTION
in my location i have 4 mirror installations running..  so I needed to be able to control each separately, thus needed unique names.. 

this adds a new optional config parm 'deviceName'
and inserts the name into multi part translation results (else the syntax gets weird)

before name restart pm2
now   restart name pm2



it also adds a new hiding capability, as none of my display devices support hardware off..
it sends a notification that allows my MMM-SleepWake to hide/show the modules

the code in node_helper handling vcgencmd, will detect old value true/false, so user doesn't have to change anything after a git pull.